### PR TITLE
Bug in e575, e576, e577.py

### DIFF
--- a/experiment_definitions/e575.py
+++ b/experiment_definitions/e575.py
@@ -205,4 +205,4 @@ def filter_activations(windows, activations):
                         activations[fold][appliance][building_name])
                 except KeyError:
                     pass
-    return activations
+    return new_activations

--- a/experiment_definitions/e575.py
+++ b/experiment_definitions/e575.py
@@ -194,8 +194,8 @@ def filter_activations(windows, activations):
     new_activations = {
         fold: {appliance: {} for appliance in APPLIANCES}
         for fold in DATA_FOLD_NAMES}
-    for fold, appliances in activations.iteritems():
-        for appliance, buildings in appliances.iteritems():
+    for fold, appliances in activations.items():
+        for appliance, buildings in appliances.items():
             required_building_ids = windows[fold].keys()
             required_building_names = [
                 'UK-DALE_building_{}'.format(i) for i in required_building_ids]

--- a/experiment_definitions/e576.py
+++ b/experiment_definitions/e576.py
@@ -196,8 +196,8 @@ def filter_activations(windows, activations):
     new_activations = {
         fold: {appliance: {} for appliance in APPLIANCES}
         for fold in DATA_FOLD_NAMES}
-    for fold, appliances in activations.iteritems():
-        for appliance, buildings in appliances.iteritems():
+    for fold, appliances in activations.items():
+        for appliance, buildings in appliances.items():
             required_building_ids = windows[fold].keys()
             required_building_names = [
                 'UK-DALE_building_{}'.format(i) for i in required_building_ids]

--- a/experiment_definitions/e576.py
+++ b/experiment_definitions/e576.py
@@ -207,4 +207,4 @@ def filter_activations(windows, activations):
                         activations[fold][appliance][building_name])
                 except KeyError:
                     pass
-    return activations
+    return new_activations

--- a/experiment_definitions/e577.py
+++ b/experiment_definitions/e577.py
@@ -255,4 +255,4 @@ def filter_activations(windows, activations):
                         activations[fold][appliance][building_name])
                 except KeyError:
                     pass
-    return activations
+    return new_activations

--- a/experiment_definitions/e577.py
+++ b/experiment_definitions/e577.py
@@ -244,8 +244,8 @@ def filter_activations(windows, activations):
     new_activations = {
         fold: {appliance: {} for appliance in APPLIANCES}
         for fold in DATA_FOLD_NAMES}
-    for fold, appliances in activations.iteritems():
-        for appliance, buildings in appliances.iteritems():
+    for fold, appliances in activations.items():
+        for appliance, buildings in appliances.items():
             required_building_ids = windows[fold].keys()
             required_building_names = [
                 'UK-DALE_building_{}'.format(i) for i in required_building_ids]

--- a/neuralnilm/data/loadactivations.py
+++ b/neuralnilm/data/loadactivations.py
@@ -44,9 +44,9 @@ def load_nilmtk_activations(appliances, filename, sample_period, windows):
     dataset = nilmtk.DataSet(filename)
 
     all_activations = {}
-    for fold, buildings_and_windows in windows.iteritems():
+    for fold, buildings_and_windows in windows.items():
         activations_for_fold = {}
-        for building_i, window in buildings_and_windows.iteritems():
+        for building_i, window in buildings_and_windows.items():
             dataset.set_window(*window)
             elec = dataset.buildings[building_i].elec
             building_name = (

--- a/neuralnilm/utils.py
+++ b/neuralnilm/utils.py
@@ -114,7 +114,7 @@ def sanitise_value_for_mogno(value):
 def sanitise_dict_for_mongo(dictionary):
     """Convert dict keys to strings (Mongo doesn't like numeric keys)"""
     new_dict = {}
-    for key, value in dictionary.iteritems():
+    for key, value in dictionary.items():
         new_dict[str(key)] = sanitise_value_for_mogno(value)
 
     return new_dict
@@ -123,8 +123,8 @@ def sanitise_dict_for_mongo(dictionary):
 def two_level_dict_to_series(dictionary):
     index = []
     values = []
-    for k0, v0 in dictionary.iteritems():
-        for k1, v1 in v0.iteritems():
+    for k0, v0 in dictionary.items():
+        for k1, v1 in v0.items():
             index.append((k0, k1))
             values.append(v1)
     return pd.Series(values, pd.MultiIndex.from_tuples(index))
@@ -132,7 +132,7 @@ def two_level_dict_to_series(dictionary):
 
 def two_level_series_to_dict(series):
     dictionary = {}
-    for (k0, k1), value in series.iteritems():
+    for (k0, k1), value in series.items():
         dictionary.setdefault(k0, {})[k1] = value
     return dictionary
 
@@ -161,8 +161,8 @@ def filter_activations(windows, activations, appliances):
     new_activations = {
         fold: {appliance: {} for appliance in appliances}
         for fold in DATA_FOLD_NAMES}
-    for fold, appliances in activations.iteritems():
-        for appliance, buildings in appliances.iteritems():
+    for fold, appliances in activations.items():
+        for appliance, buildings in appliances.items():
             required_building_ids = windows[fold].keys()
             required_building_names = [
                 'UK-DALE_building_{}'.format(i) for i in required_building_ids]


### PR DESCRIPTION
In e575, e576, e577.py, `filter_activations` method, the return should be `new_activations `instead of `activations`.